### PR TITLE
Support Heading Tabs in Config — (quick feedback idea)

### DIFF
--- a/generic-tabs/GenericTabs.js
+++ b/generic-tabs/GenericTabs.js
@@ -36,7 +36,9 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
       selectors: {
         tabs: {
           selector: el =>
-            Array.from(el.children).filter(_ => _.matches('h1, h2, h3, h4, h5, h6, [slot="tab"]')),
+            Array.from(el.children).filter(
+              _ => _ instanceof HTMLHeadingElement || _.slot === 'tab',
+            ),
           focusTarget: true,
         },
         panels: {
@@ -44,7 +46,7 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
             Array.from(el.children).filter(
               _ =>
                 _.matches('h1 ~ *, h2 ~ *, h3 ~ *, h4 ~ *, h5 ~ *, h6 ~ *, [slot="panel"]') &&
-                !_.matches('h1, h2, h3, h4, h5, h6, [slot="tab"]'),
+                !(_ instanceof HTMLHeadingElement || _.slot === 'tab'),
             ),
         },
       },

--- a/generic-tabs/test/generic-tabs.test.js
+++ b/generic-tabs/test/generic-tabs.test.js
@@ -65,8 +65,8 @@ describe('generic-tabs', () => {
     const el = await fixture(tabsFixture);
 
     const tablist = el.shadowRoot.querySelector('[role="tablist"]');
-    const panel = el.querySelector('div[slot="panel"]');
-    const button = el.querySelector('button[slot="tab"]');
+    const panel = el.querySelector('[slot="panel"]');
+    const button = el.querySelector('[slot="tab"]');
 
     expect(tablist.getAttribute('role')).to.equal('tablist');
     expect(tablist.getAttribute('aria-label')).to.equal('tablist');
@@ -84,8 +84,8 @@ describe('generic-tabs', () => {
     const el = await fixture(tabsFixture);
 
     const tablist = el.shadowRoot.querySelector('[role="tablist"]');
-    const panel = el.querySelector('div[slot="panel"]');
-    const button = el.querySelector('button[slot="tab"]');
+    const panel = el.querySelector('[slot="panel"]');
+    const button = el.querySelector('[slot="tab"]');
 
     expect(tablist.getAttribute('role')).to.equal('tablist');
     expect(tablist.getAttribute('aria-label')).to.equal('tablist');
@@ -107,8 +107,8 @@ describe('generic-tabs', () => {
 
     await el.updateComplete;
 
-    const newpanel = el.querySelectorAll('div[slot="panel"]')[2];
-    const newbutton = el.querySelectorAll('button[slot="tab"]')[2];
+    const newpanel = el.querySelectorAll('[slot="panel"]')[2];
+    const newbutton = el.querySelectorAll('[slot="tab"]')[2];
 
     expect(newpanel.getAttribute('role')).to.equal('tabpanel');
     expect(newpanel.hasAttribute('aria-labelledby')).to.equal(true);


### PR DESCRIPTION
Hi, Dave 👋 !

This PR modifies your nifty "_headings as automatic tabs_" PR so that the additional pre-processing step is removed, and instead it supports them in the component config.

I let the code run through the project linter and it should be ~laundered~ _compliant_ now.